### PR TITLE
[BUGFIX] Fix crash on physical hosts

### DIFF
--- a/.kitchen.dokken.yml
+++ b/.kitchen.dokken.yml
@@ -1,0 +1,46 @@
+#
+# test-kitchen using kitchen-dokken
+#
+# to use this instead of Vagrant, use:
+#
+#   $ KITCHEN_LOCAL_YAML=.kitchen.dokken.yml kitchen verify
+#
+driver:
+  name: dokken
+  privileged: true # because Docker and SystemD/Upstart
+
+transport:
+  name: dokken
+
+provisioner:
+  name: dokken
+
+platforms:
+#- name: debian-9
+#  driver:
+#    image: debian:9
+#    pid_one_command: /bin/systemd
+#    intermediate_instructions:
+#      - RUN /usr/bin/apt-get update
+#      - RUN /usr/bin/apt-get install systemd -y
+#      - RUN /usr/bin/apt-get install gpg -y
+#      - RUN /usr/bin/apt-get install apt-transport-https lsb-release procps net-tools -y
+
+- name: debian-8
+  driver:
+    image: debian:8
+    pid_one_command: /bin/systemd
+    intermediate_instructions:
+      - RUN /usr/bin/apt-get update
+      - RUN /usr/bin/apt-get install apt-transport-https lsb-release procps net-tools -y
+
+# comment this out, if Debian 7 is not needed
+- name: debian-7
+  driver:
+    image: debian:7
+    intermediate_instructions:
+      - RUN /usr/bin/apt-get update
+      - RUN /usr/bin/apt-get install apt-transport-https lsb-release procps net-tools -y
+
+# suites are taken from .kitchen.yml usually
+# suites:

--- a/.kitchen.dokken.yml
+++ b/.kitchen.dokken.yml
@@ -40,7 +40,7 @@ platforms:
     image: debian:7
     intermediate_instructions:
       - RUN /usr/bin/apt-get update
-      - RUN /usr/bin/apt-get install apt-transport-https lsb-release procps net-tools -y
+      - RUN /usr/bin/apt-get install apt-transport-https lsb-release procps net-tools cron -y
 
 # suites are taken from .kitchen.yml usually
 # suites:

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -7,6 +7,9 @@ driver:
 provisioner:
   name: chef_zero
 
+verifier:
+  name: inspec
+
 platforms:
 - name: debian-7.11
   run_list:
@@ -21,6 +24,12 @@ suites:
   run_list:
     - recipe[t3-zabbix::agent]
   attributes:
+    zabbix:
+      agent:
+        servers:
+        - localhost
+        servers_active:
+        - localhost
 
 - name: server
   excludes: debian-8.6

--- a/metadata.rb
+++ b/metadata.rb
@@ -9,7 +9,9 @@ version          IO.read(File.join(File.dirname(__FILE__), 'VERSION')) rescue '0
 depends          "build-essential"
 depends          "zabbix", "= 0.0.43"
 depends          "zabbix-custom-checks"
-depends          "chef_handler"
+
+depends          "chef_handler", "< 3.0.0" # https://github.com/chef-cookbooks/chef_handler/issues/61
+depends          "systemd"
 
 # only for testing
 depends          "apt"

--- a/recipes/agent.rb
+++ b/recipes/agent.rb
@@ -14,6 +14,7 @@ resources("template[/etc/init.d/zabbix_agentd]").cookbook "t3-zabbix"
 # https://support.zabbix.com/browse/ZBX-11544
 if node['lsb']['release'].to_i >= 8 && (!node.has_key?('virtualization') || node['virtualization']['role'] != 'guest')
   log 'Adjusting systemd\'s logind.conf to avoid ZBX-11544'
+  node.default['systemd']['logind']['n_auto_v_ts'] = nil
   node.default['systemd']['logind']['remove_ipc'] = false
   include_recipe 'systemd::logind'
 end

--- a/recipes/agent.rb
+++ b/recipes/agent.rb
@@ -8,3 +8,12 @@ resources("template[#{node['zabbix']['etc_dir']}/zabbix_agentd.conf]").cookbook 
 
 # why is writing LSB-compliant init scripts so hard?
 resources("template[/etc/init.d/zabbix_agentd]").cookbook "t3-zabbix"
+
+# in case of physical Debian 8+ systems, adjust systemd
+# https://forge.typo3.org/issues/79563
+# https://support.zabbix.com/browse/ZBX-11544
+if node['lsb']['release'].to_i >= 8 && (!node.has_key?('virtualization') || node['virtualization']['role'] != 'guest')
+  log 'Adjusting systemd\'s logind.conf to avoid ZBX-11544'
+  node.default['systemd']['logind']['remove_ipc'] = false
+  include_recipe 'systemd::logind'
+end

--- a/test/integration/agent/inspec/agent_spec.rb
+++ b/test/integration/agent/inspec/agent_spec.rb
@@ -1,0 +1,11 @@
+control 't3zabbix-agent-1' do
+  title 'Zabbix Agent'
+
+  # can test this only on physical nodes.. :-(
+  # if os['family'] == 'debian' && os['release'].to_i >= 8
+  #   describe file('/etc/systemd/logind.conf') do
+  #     its('content') { should match %r(RemoveIPC=no) }
+  #   end
+  # end
+
+end


### PR DESCRIPTION
Zabbix Agent used to fail on all our physical Debian 8 hosts with the following errors:

> zabbix_agentd [16665]: [file:'cpustat.c',line:252] lock failed: [22] Invalid argument
> zabbix_agentd [16664]: [file:'log.c',line:271] lock failed: [22] Invalid argument
> zabbix_agentd [16666]: [file:'log.c',line:271] lock failed: [22] Invalid argument

This is tracked under ZBX-11544 and can be fixed by setting `RemoveIPC=non` in `/etc/systemd/logind.conf`.

Fixes: [#79563](https://forge.typo3.org/issues/79563)