### PR TITLE
[BUGFIX] Apply logind fix only if systemd is installed

### DIFF
--- a/recipes/agent.rb
+++ b/recipes/agent.rb
@@ -9,10 +9,10 @@ resources("template[#{node['zabbix']['etc_dir']}/zabbix_agentd.conf]").cookbook 
 # why is writing LSB-compliant init scripts so hard?
 resources("template[/etc/init.d/zabbix_agentd]").cookbook "t3-zabbix"
 
-# in case of Debian 8+ systems, adjust systemd
+# in case of Debian 8+ systems which are running with systemd, adjust logind
 # https://forge.typo3.org/issues/79563
 # https://support.zabbix.com/browse/ZBX-11544
-if node['lsb']['release'].to_i >= 8
+if node['lsb']['release'].to_i >= 8 && node.key?('init_package') && node['init_package'] == 'systemd'
   log 'Adjusting systemd\'s logind.conf to avoid ZBX-11544'
   node.default['systemd']['logind']['n_auto_v_ts'] = nil
   node.default['systemd']['logind']['remove_ipc'] = false


### PR DESCRIPTION
Don't include the systemd cookbook on systems where SysV init is used.

Fixes: https://forge.typo3.org/issues/82219

See also #1 #3 